### PR TITLE
test(e2e): resilient locators and fixture-based lifecycle

### DIFF
--- a/e2e/components/PositionSlider.ts
+++ b/e2e/components/PositionSlider.ts
@@ -7,8 +7,8 @@ export class PositionSlider {
 
   constructor(page: Page) {
     this.page = page
-    this.slider = page.locator('.p-slider')
-    this.breakoutTick = page.locator('.breakout-tick')
+    this.slider = page.getByTestId('position-slider')
+    this.breakoutTick = page.getByTestId('breakout-tick')
   }
 
   async getSliderBoundingBox() {

--- a/e2e/components/StatusOverlay.ts
+++ b/e2e/components/StatusOverlay.ts
@@ -8,11 +8,11 @@ export class StatusOverlay {
   readonly distanceValue: Locator
 
   constructor(page: Page) {
-    this.container = page.locator('.status-overlay')
-    this.altitudeLabel = this.container.locator('.status-label:has-text("Altitude:")')
-    this.distanceLabel = this.container.locator('.status-label:has-text("Distance:")')
-    this.altitudeValue = this.container.locator('.status-value').first()
-    this.distanceValue = this.container.locator('.status-value').last()
+    this.container = page.getByTestId('status-overlay')
+    this.altitudeLabel = this.container.getByTestId('status-altitude-label')
+    this.distanceLabel = this.container.getByTestId('status-distance-label')
+    this.altitudeValue = this.container.getByTestId('status-altitude-value')
+    this.distanceValue = this.container.getByTestId('status-distance-value')
   }
 
   async getAltitudeText(): Promise<string | null> {

--- a/e2e/fixtures/fixtures.ts
+++ b/e2e/fixtures/fixtures.ts
@@ -2,9 +2,43 @@ import { test as base } from '@playwright/test'
 import { ApproachVisualizerPage } from '../pages/ApproachVisualizerPage'
 import { WebGLErrorPage } from '../pages/WebGLErrorPage'
 
+/**
+ * Init script that forces every WebGL context creation to fail, so the app
+ * falls back to its "WebGL Not Supported" error UI. Injected by the
+ * webGLDisabledErrorPage fixture before the page navigates.
+ */
+const webGLDisableScript = () => {
+  const originalGetContext = HTMLCanvasElement.prototype.getContext
+  HTMLCanvasElement.prototype.getContext = function (
+    this: HTMLCanvasElement,
+    contextType: string,
+    ...args: unknown[]
+  ): RenderingContext | null {
+    if (
+      contextType === 'webgl' ||
+      contextType === 'webgl2' ||
+      contextType === 'experimental-webgl' ||
+      contextType === 'experimental-webgl2'
+    ) {
+      return null
+    }
+    return originalGetContext.apply(this, [contextType, ...args] as Parameters<
+      typeof originalGetContext
+    >) as RenderingContext | null
+  }
+
+  if (typeof WebGLRenderingContext !== 'undefined') {
+    ;(window as Window & { WebGLRenderingContext?: undefined }).WebGLRenderingContext = undefined
+  }
+  if (typeof WebGL2RenderingContext !== 'undefined') {
+    ;(window as Window & { WebGL2RenderingContext?: undefined }).WebGL2RenderingContext = undefined
+  }
+}
+
 type Fixtures = {
   approachPage: ApproachVisualizerPage
   webGLErrorPage: WebGLErrorPage
+  webGLDisabledErrorPage: WebGLErrorPage
 }
 
 export const test = base.extend<Fixtures>({
@@ -13,6 +47,30 @@ export const test = base.extend<Fixtures>({
   },
   webGLErrorPage: async ({ page }, use) => {
     await use(new WebGLErrorPage(page))
+  },
+  /**
+   * A WebGLErrorPage backed by a context in which WebGL is disabled, already
+   * navigated to the app. The fixture owns the context lifecycle (creation,
+   * the WebGL-disable init script, and teardown); specs only assert. Honors
+   * the active `viewport` and `browserName` test options, so a spec can
+   * exercise the mobile layout via `test.use({ viewport })`.
+   */
+  webGLDisabledErrorPage: async ({ browser, browserName, viewport }, use) => {
+    const context = await browser.newContext({
+      ...(viewport ? { viewport } : {}),
+      ...(browserName === 'chromium' && {
+        args: ['--disable-webgl', '--disable-webgl2'],
+      }),
+    })
+    const page = await context.newPage()
+    await page.addInitScript(webGLDisableScript)
+
+    const errorPage = new WebGLErrorPage(page)
+    await errorPage.goto()
+
+    await use(errorPage)
+
+    await context.close()
   },
 })
 

--- a/e2e/locale.spec.ts
+++ b/e2e/locale.spec.ts
@@ -1,9 +1,6 @@
 import { test, expect } from './fixtures/fixtures'
 import { LocaleSwitcher } from './components/LocaleSwitcher'
 
-const approachMinimumLabel = (page: import('@playwright/test').Page) =>
-  page.locator('label[for="approach-minimum"]')
-
 test.describe('Localization', () => {
   test.describe('German on a mobile viewport', () => {
     test.use({ locale: 'de-DE', viewport: { width: 360, height: 780 } })
@@ -15,7 +12,7 @@ test.describe('Localization', () => {
       await expect(approachPage.header).toBeVisible({ timeout: 10000 })
 
       // Browser preference (de-DE) is detected and reflected on <html lang>.
-      await expect(approachMinimumLabel(approachPage.page)).toHaveText('Anflugminimum')
+      await expect(approachPage.approachMinimumLabel).toHaveText('Anflugminimum')
       await expect(approachPage.page.locator('html')).toHaveAttribute('lang', 'de-DE')
 
       // German is verbose: the layout must not overflow the narrow viewport.
@@ -35,12 +32,12 @@ test.describe('Localization', () => {
     }) => {
       await approachPage.goto()
       await expect(approachPage.header).toBeVisible({ timeout: 10000 })
-      await expect(approachMinimumLabel(approachPage.page)).toHaveText('Approach Minimum')
+      await expect(approachPage.approachMinimumLabel).toHaveText('Approach Minimum')
 
       const switcher = new LocaleSwitcher(approachPage.page)
       await switcher.choose('Deutsch (Deutschland)')
 
-      await expect(approachMinimumLabel(approachPage.page)).toHaveText('Anflugminimum')
+      await expect(approachPage.approachMinimumLabel).toHaveText('Anflugminimum')
       await expect(approachPage.page.locator('html')).toHaveAttribute('lang', 'de-DE')
 
       const stored = await approachPage.page.evaluate(() =>

--- a/e2e/pages/ApproachVisualizerPage.ts
+++ b/e2e/pages/ApproachVisualizerPage.ts
@@ -9,6 +9,7 @@ export class ApproachVisualizerPage {
   readonly canvas: Locator
   readonly formFields: Locator
   readonly controls: Locator
+  readonly approachMinimumLabel: Locator
   readonly statusOverlay: StatusOverlay
   readonly animationControls: AnimationControls
   readonly positionSlider: PositionSlider
@@ -19,6 +20,7 @@ export class ApproachVisualizerPage {
     this.canvas = page.locator('canvas.babylon-canvas')
     this.formFields = page.locator('.form-field')
     this.controls = page.locator('button, input, select')
+    this.approachMinimumLabel = page.locator('label[for="approach-minimum"]')
     this.statusOverlay = new StatusOverlay(page)
     this.animationControls = new AnimationControls(page)
     this.positionSlider = new PositionSlider(page)

--- a/e2e/webgl-error.spec.ts
+++ b/e2e/webgl-error.spec.ts
@@ -1,84 +1,35 @@
 import { test, expect } from './fixtures/fixtures'
-import { WebGLErrorPage } from './pages/WebGLErrorPage'
-import { ApproachVisualizerPage } from './pages/ApproachVisualizerPage'
-
-const webGLDisableScript = () => {
-  // Override the WebGL context creation to always fail
-  const originalGetContext = HTMLCanvasElement.prototype.getContext
-  HTMLCanvasElement.prototype.getContext = function (
-    this: HTMLCanvasElement,
-    contextType: string,
-    ...args: unknown[]
-  ): RenderingContext | null {
-    if (
-      contextType === 'webgl' ||
-      contextType === 'webgl2' ||
-      contextType === 'experimental-webgl' ||
-      contextType === 'experimental-webgl2'
-    ) {
-      return null
-    }
-    return originalGetContext.apply(this, [contextType, ...args] as Parameters<
-      typeof originalGetContext
-    >) as RenderingContext | null
-  }
-
-  // Also override WebGLRenderingContext if it exists
-  if (typeof WebGLRenderingContext !== 'undefined') {
-    ;(window as Window & { WebGLRenderingContext?: undefined }).WebGLRenderingContext = undefined
-  }
-  if (typeof WebGL2RenderingContext !== 'undefined') {
-    ;(window as Window & { WebGL2RenderingContext?: undefined }).WebGL2RenderingContext = undefined
-  }
-}
 
 test.describe('WebGL Error Handling', () => {
-  test('displays error message when WebGL is disabled', async ({ browser }) => {
-    // Create a new context with WebGL disabled
-    const context = await browser.newContext({
-      ...(browser.browserType().name() === 'chromium' && {
-        args: ['--disable-webgl', '--disable-webgl2'],
-      }),
-    })
-
-    const page = await context.newPage()
-    await page.addInitScript(webGLDisableScript)
-
-    const errorPage = new WebGLErrorPage(page)
-    await errorPage.goto()
-
+  test('displays error message when WebGL is disabled', async ({ webGLDisabledErrorPage }) => {
     // Check if the WebGL error message is displayed
-    await expect(errorPage.errorContainer).toBeVisible({ timeout: 10000 })
+    await expect(webGLDisabledErrorPage.errorContainer).toBeVisible({ timeout: 10000 })
 
     // Verify the error message content
-    await expect(errorPage.errorTitle).toHaveText('WebGL Not Supported')
+    await expect(webGLDisabledErrorPage.errorTitle).toHaveText('WebGL Not Supported')
 
     // Verify that helpful suggestions are shown
-    await expect(errorPage.suggestions).toHaveCount(4)
+    await expect(webGLDisabledErrorPage.suggestions).toHaveCount(4)
 
     // Check specific suggestion text
-    await expect(errorPage.getSuggestionAt(0)).toContainText('modern browser')
-    await expect(errorPage.getSuggestionAt(1)).toContainText('hardware acceleration')
-    await expect(errorPage.getSuggestionAt(2)).toContainText('graphics drivers')
-    await expect(errorPage.getSuggestionAt(3)).toContainText('WebGL is blocked')
+    await expect(webGLDisabledErrorPage.getSuggestionAt(0)).toContainText('modern browser')
+    await expect(webGLDisabledErrorPage.getSuggestionAt(1)).toContainText('hardware acceleration')
+    await expect(webGLDisabledErrorPage.getSuggestionAt(2)).toContainText('graphics drivers')
+    await expect(webGLDisabledErrorPage.getSuggestionAt(3)).toContainText('WebGL is blocked')
 
     // Verify that the status overlay is NOT displayed
-    await expect(errorPage.statusOverlay).toBeHidden()
+    await expect(webGLDisabledErrorPage.statusOverlay).toBeHidden()
 
     // Verify that the canvas still exists (even though WebGL failed)
-    await expect(errorPage.canvas).toBeVisible()
-
-    await context.close()
+    await expect(webGLDisabledErrorPage.canvas).toBeVisible()
   })
 
-  test('renders 3D scene when WebGL is enabled', async ({ page }) => {
-    const approachPage = new ApproachVisualizerPage(page)
+  test('renders 3D scene when WebGL is enabled', async ({ approachPage, webGLErrorPage }) => {
     await approachPage.goto()
-    await page.waitForLoadState('domcontentloaded')
+    await approachPage.page.waitForLoadState('domcontentloaded')
 
     // Verify that the error message is NOT displayed
-    const errorPage = new WebGLErrorPage(page)
-    await expect(errorPage.errorContainer).toBeHidden()
+    await expect(webGLErrorPage.errorContainer).toBeHidden()
 
     // Verify that the status overlay IS displayed
     await expect(approachPage.statusOverlay.container).toBeVisible({ timeout: 10000 })
@@ -91,33 +42,21 @@ test.describe('WebGL Error Handling', () => {
     await expect(approachPage.canvas).toBeVisible()
   })
 
-  test('error message is responsive on mobile', async ({ browser }) => {
-    // Create a mobile viewport context with WebGL disabled
-    const context = await browser.newContext({
-      viewport: { width: 375, height: 667 },
-      ...(browser.browserType().name() === 'chromium' && {
-        args: ['--disable-webgl', '--disable-webgl2'],
-      }),
+  test.describe('on a mobile viewport', () => {
+    test.use({ viewport: { width: 375, height: 667 } })
+
+    test('error message is responsive', async ({ webGLDisabledErrorPage }) => {
+      // Check that error message is displayed and responsive
+      await expect(webGLDisabledErrorPage.errorContainer).toBeVisible({ timeout: 10000 })
+
+      // Verify responsive styling
+      const boundingBox = await webGLDisabledErrorPage.getErrorContainerBoundingBox()
+      expect(boundingBox).toBeTruthy()
+
+      // On mobile, the error container should be 95% width
+      const viewportWidth = 375
+      const expectedMaxWidth = viewportWidth * 0.95
+      expect(boundingBox!.width).toBeLessThanOrEqual(expectedMaxWidth)
     })
-
-    const page = await context.newPage()
-    await page.addInitScript(webGLDisableScript)
-
-    const errorPage = new WebGLErrorPage(page)
-    await errorPage.goto()
-
-    // Check that error message is displayed and responsive
-    await expect(errorPage.errorContainer).toBeVisible({ timeout: 10000 })
-
-    // Verify responsive styling
-    const boundingBox = await errorPage.getErrorContainerBoundingBox()
-    expect(boundingBox).toBeTruthy()
-
-    // On mobile, the error container should be 95% width
-    const viewportWidth = 375
-    const expectedMaxWidth = viewportWidth * 0.95
-    expect(boundingBox!.width).toBeLessThanOrEqual(expectedMaxWidth)
-
-    await context.close()
   })
 })

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -488,6 +488,7 @@ useTimeoutFn(() => {
           <Slider
             v-model="positionSlider"
             class="full-width-slider"
+            data-testid="position-slider"
             :min="0"
             :max="100"
             :step="0.1"
@@ -499,6 +500,7 @@ useTimeoutFn(() => {
             :key="`tick-${index}`"
             class="visibility-tick"
             :class="mark.class"
+            :data-testid="mark.class"
             :style="{ left: `${mark.position}%` }"
             v-tooltip.top="mark.label"
           >

--- a/src/components/RunwayViewer.vue
+++ b/src/components/RunwayViewer.vue
@@ -93,11 +93,14 @@ watch(
     </div>
 
     <!-- Status Overlay -->
-    <div v-else class="status-overlay">
+    <div v-else class="status-overlay" data-testid="status-overlay">
       <div class="status-item">
-        <span class="status-label">{{ t('status.altitude') }}</span>
+        <span class="status-label" data-testid="status-altitude-label">{{
+          t('status.altitude')
+        }}</span>
         <span
           class="status-value"
+          data-testid="status-altitude-value"
           :class="{
             'below-ceiling': animationStore.currentAltitude <= approachStore.effectiveCeiling,
           }"
@@ -105,10 +108,15 @@ watch(
         >
       </div>
       <div class="status-item">
-        <span class="status-label">{{ t('status.distance') }}</span>
-        <span class="status-value" :class="{ 'within-visibility': isWithinVisibility }">{{
-          formatNauticalMiles(animationStore.currentDistanceNm)
+        <span class="status-label" data-testid="status-distance-label">{{
+          t('status.distance')
         }}</span>
+        <span
+          class="status-value"
+          data-testid="status-distance-value"
+          :class="{ 'within-visibility': isWithinVisibility }"
+          >{{ formatNauticalMiles(animationStore.currentDistanceNm) }}</span
+        >
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Brings the Playwright E2E layer in line with the UI test guidance: resilient locators (testid/role over CSS class chains and positional indexes) and fixtures owning per-test lifecycle.

## Findings addressed

**Finding 1 — locator resilience.** The component objects reached into CSS classes and positional `.first()`/`.last()` selectors that restyling would break.
- Added `data-testid` attributes to the real component source: the status overlay container, each altitude/distance label and value (`src/components/RunwayViewer.vue`), the position slider, and the visibility tick marks (`src/components/AppHeader.vue`, the tick `data-testid` reuses each mark's stable identifier).
- Switched `e2e/components/StatusOverlay.ts` and `e2e/components/PositionSlider.ts` from `.status-label:has-text(...)` / `.status-value` `first()`/`last()` / `.p-slider` / `.breakout-tick` to `getByTestId(...)`.

**Finding 2 — fixtures / layering.** Specs constructed page objects directly (`new WebGLErrorPage(page)` / `new ApproachVisualizerPage(page)`) and inlined raw locators, bypassing the fixtures.
- Added a `webGLDisabledErrorPage` fixture (`e2e/fixtures/fixtures.ts`) that owns the WebGL-disabled context lifecycle — context creation, the WebGL-disable init script, navigation, and teardown — and honors the active `viewport`/`browserName` test options. `e2e/webgl-error.spec.ts` now consumes it instead of building contexts and page objects inline; the mobile case is expressed via `test.use({ viewport })`.
- Routed the "renders 3D scene" test through the existing `approachPage` / `webGLErrorPage` fixtures.
- Moved `locale.spec.ts`'s inlined `label[for="approach-minimum"]` locator onto `ApproachVisualizerPage` as `approachMinimumLabel`.

Nothing deferred.

## Verification

All run with pnpm on this branch:
- `pnpm type-check` (vue-tsc) — pass
- `pnpm lint` (eslint + stylelint + oxlint + knip) — pass
- `pnpm test:unit` (vitest) — 14 passed
- `npx playwright test --list` — 33 tests compile across 5 specs
- `pnpm build` — succeeds (needed for the preview server)
- Full Playwright run on the `chromium` project — **11/11 passed** across all 5 spec files (webgl-error 3, locale 2, non-precision 4, slider 1, approach-visualizer 1). This exercises the new test ids end-to-end: the slider drag locates via `getByTestId('position-slider')` and the breakout-tick / status-overlay assertions confirm the attributes render. Firefox/WebKit projects were not run locally; CI covers them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)