### PR TITLE
Harden E2E locators and route specs through fixtures

### DIFF
--- a/e2e/components/PositionSlider.ts
+++ b/e2e/components/PositionSlider.ts
@@ -7,8 +7,8 @@ export class PositionSlider {
 
   constructor(page: Page) {
     this.page = page
-    this.slider = page.locator('.p-slider')
-    this.breakoutTick = page.locator('.breakout-tick')
+    this.slider = page.getByTestId('position-slider')
+    this.breakoutTick = page.getByTestId('breakout-tick')
   }
 
   async getSliderBoundingBox() {

--- a/e2e/components/StatusOverlay.ts
+++ b/e2e/components/StatusOverlay.ts
@@ -8,11 +8,11 @@ export class StatusOverlay {
   readonly distanceValue: Locator
 
   constructor(page: Page) {
-    this.container = page.locator('.status-overlay')
-    this.altitudeLabel = this.container.locator('.status-label:has-text("Altitude:")')
-    this.distanceLabel = this.container.locator('.status-label:has-text("Distance:")')
-    this.altitudeValue = this.container.locator('.status-value').first()
-    this.distanceValue = this.container.locator('.status-value').last()
+    this.container = page.getByTestId('status-overlay')
+    this.altitudeLabel = this.container.getByTestId('altitude-label')
+    this.distanceLabel = this.container.getByTestId('distance-label')
+    this.altitudeValue = this.container.getByTestId('altitude-value')
+    this.distanceValue = this.container.getByTestId('distance-value')
   }
 
   async getAltitudeText(): Promise<string | null> {

--- a/e2e/fixtures/fixtures.ts
+++ b/e2e/fixtures/fixtures.ts
@@ -2,12 +2,61 @@ import { test as base } from '@playwright/test'
 import { ApproachVisualizerPage } from '../pages/ApproachVisualizerPage'
 import { WebGLErrorPage } from '../pages/WebGLErrorPage'
 
+/**
+ * Init script that forces every WebGL context request to fail, so the app
+ * falls back to its "WebGL Not Supported" error state. Defined as a string
+ * because it is serialized and evaluated in the browser via addInitScript.
+ */
+const disableWebGL = () => {
+  const originalGetContext = HTMLCanvasElement.prototype.getContext
+  HTMLCanvasElement.prototype.getContext = function (
+    this: HTMLCanvasElement,
+    contextType: string,
+    ...args: unknown[]
+  ): RenderingContext | null {
+    if (
+      contextType === 'webgl' ||
+      contextType === 'webgl2' ||
+      contextType === 'experimental-webgl' ||
+      contextType === 'experimental-webgl2'
+    ) {
+      return null
+    }
+    return originalGetContext.apply(this, [contextType, ...args] as Parameters<
+      typeof originalGetContext
+    >) as RenderingContext | null
+  }
+
+  if (typeof WebGLRenderingContext !== 'undefined') {
+    ;(window as Window & { WebGLRenderingContext?: undefined }).WebGLRenderingContext = undefined
+  }
+  if (typeof WebGL2RenderingContext !== 'undefined') {
+    ;(window as Window & { WebGL2RenderingContext?: undefined }).WebGL2RenderingContext = undefined
+  }
+}
+
+type Options = {
+  /**
+   * When true, WebGL context creation is forced to fail before any navigation,
+   * driving the app into its WebGL error state. Opt in per test with
+   * `test.use({ webGLDisabled: true })`.
+   */
+  webGLDisabled: boolean
+}
+
 type Fixtures = {
   approachPage: ApproachVisualizerPage
   webGLErrorPage: WebGLErrorPage
 }
 
-export const test = base.extend<Fixtures>({
+export const test = base.extend<Options & Fixtures>({
+  webGLDisabled: [false, { option: true }],
+  page: async ({ page, webGLDisabled }, use) => {
+    if (webGLDisabled) {
+      await page.addInitScript(disableWebGL)
+    }
+    await use(page)
+  },
   approachPage: async ({ page }, use) => {
     await use(new ApproachVisualizerPage(page))
   },

--- a/e2e/locale.spec.ts
+++ b/e2e/locale.spec.ts
@@ -1,9 +1,6 @@
 import { test, expect } from './fixtures/fixtures'
 import { LocaleSwitcher } from './components/LocaleSwitcher'
 
-const approachMinimumLabel = (page: import('@playwright/test').Page) =>
-  page.locator('label[for="approach-minimum"]')
-
 test.describe('Localization', () => {
   test.describe('German on a mobile viewport', () => {
     test.use({ locale: 'de-DE', viewport: { width: 360, height: 780 } })
@@ -15,7 +12,7 @@ test.describe('Localization', () => {
       await expect(approachPage.header).toBeVisible({ timeout: 10000 })
 
       // Browser preference (de-DE) is detected and reflected on <html lang>.
-      await expect(approachMinimumLabel(approachPage.page)).toHaveText('Anflugminimum')
+      await expect(approachPage.approachMinimumLabel).toHaveText('Anflugminimum')
       await expect(approachPage.page.locator('html')).toHaveAttribute('lang', 'de-DE')
 
       // German is verbose: the layout must not overflow the narrow viewport.
@@ -35,12 +32,12 @@ test.describe('Localization', () => {
     }) => {
       await approachPage.goto()
       await expect(approachPage.header).toBeVisible({ timeout: 10000 })
-      await expect(approachMinimumLabel(approachPage.page)).toHaveText('Approach Minimum')
+      await expect(approachPage.approachMinimumLabel).toHaveText('Approach Minimum')
 
       const switcher = new LocaleSwitcher(approachPage.page)
       await switcher.choose('Deutsch (Deutschland)')
 
-      await expect(approachMinimumLabel(approachPage.page)).toHaveText('Anflugminimum')
+      await expect(approachPage.approachMinimumLabel).toHaveText('Anflugminimum')
       await expect(approachPage.page.locator('html')).toHaveAttribute('lang', 'de-DE')
 
       const stored = await approachPage.page.evaluate(() =>

--- a/e2e/pages/ApproachVisualizerPage.ts
+++ b/e2e/pages/ApproachVisualizerPage.ts
@@ -9,6 +9,7 @@ export class ApproachVisualizerPage {
   readonly canvas: Locator
   readonly formFields: Locator
   readonly controls: Locator
+  readonly approachMinimumLabel: Locator
   readonly statusOverlay: StatusOverlay
   readonly animationControls: AnimationControls
   readonly positionSlider: PositionSlider
@@ -19,6 +20,7 @@ export class ApproachVisualizerPage {
     this.canvas = page.locator('canvas.babylon-canvas')
     this.formFields = page.locator('.form-field')
     this.controls = page.locator('button, input, select')
+    this.approachMinimumLabel = page.getByTestId('approach-minimum-label')
     this.statusOverlay = new StatusOverlay(page)
     this.animationControls = new AnimationControls(page)
     this.positionSlider = new PositionSlider(page)

--- a/e2e/webgl-error.spec.ts
+++ b/e2e/webgl-error.spec.ts
@@ -1,84 +1,61 @@
 import { test, expect } from './fixtures/fixtures'
-import { WebGLErrorPage } from './pages/WebGLErrorPage'
-import { ApproachVisualizerPage } from './pages/ApproachVisualizerPage'
-
-const webGLDisableScript = () => {
-  // Override the WebGL context creation to always fail
-  const originalGetContext = HTMLCanvasElement.prototype.getContext
-  HTMLCanvasElement.prototype.getContext = function (
-    this: HTMLCanvasElement,
-    contextType: string,
-    ...args: unknown[]
-  ): RenderingContext | null {
-    if (
-      contextType === 'webgl' ||
-      contextType === 'webgl2' ||
-      contextType === 'experimental-webgl' ||
-      contextType === 'experimental-webgl2'
-    ) {
-      return null
-    }
-    return originalGetContext.apply(this, [contextType, ...args] as Parameters<
-      typeof originalGetContext
-    >) as RenderingContext | null
-  }
-
-  // Also override WebGLRenderingContext if it exists
-  if (typeof WebGLRenderingContext !== 'undefined') {
-    ;(window as Window & { WebGLRenderingContext?: undefined }).WebGLRenderingContext = undefined
-  }
-  if (typeof WebGL2RenderingContext !== 'undefined') {
-    ;(window as Window & { WebGL2RenderingContext?: undefined }).WebGL2RenderingContext = undefined
-  }
-}
 
 test.describe('WebGL Error Handling', () => {
-  test('displays error message when WebGL is disabled', async ({ browser }) => {
-    // Create a new context with WebGL disabled
-    const context = await browser.newContext({
-      ...(browser.browserType().name() === 'chromium' && {
-        args: ['--disable-webgl', '--disable-webgl2'],
-      }),
+  test.describe('with WebGL disabled', () => {
+    test.use({ webGLDisabled: true })
+
+    test('displays error message when WebGL is disabled', async ({ webGLErrorPage }) => {
+      await webGLErrorPage.goto()
+
+      // Check if the WebGL error message is displayed
+      await expect(webGLErrorPage.errorContainer).toBeVisible({ timeout: 10000 })
+
+      // Verify the error message content
+      await expect(webGLErrorPage.errorTitle).toHaveText('WebGL Not Supported')
+
+      // Verify that helpful suggestions are shown
+      await expect(webGLErrorPage.suggestions).toHaveCount(4)
+
+      // Check specific suggestion text
+      await expect(webGLErrorPage.getSuggestionAt(0)).toContainText('modern browser')
+      await expect(webGLErrorPage.getSuggestionAt(1)).toContainText('hardware acceleration')
+      await expect(webGLErrorPage.getSuggestionAt(2)).toContainText('graphics drivers')
+      await expect(webGLErrorPage.getSuggestionAt(3)).toContainText('WebGL is blocked')
+
+      // Verify that the status overlay is NOT displayed
+      await expect(webGLErrorPage.statusOverlay).toBeHidden()
+
+      // Verify that the canvas still exists (even though WebGL failed)
+      await expect(webGLErrorPage.canvas).toBeVisible()
     })
 
-    const page = await context.newPage()
-    await page.addInitScript(webGLDisableScript)
+    test.describe('on a mobile viewport', () => {
+      test.use({ viewport: { width: 375, height: 667 } })
 
-    const errorPage = new WebGLErrorPage(page)
-    await errorPage.goto()
+      test('error message is responsive on mobile', async ({ webGLErrorPage }) => {
+        await webGLErrorPage.goto()
 
-    // Check if the WebGL error message is displayed
-    await expect(errorPage.errorContainer).toBeVisible({ timeout: 10000 })
+        // Check that error message is displayed and responsive
+        await expect(webGLErrorPage.errorContainer).toBeVisible({ timeout: 10000 })
 
-    // Verify the error message content
-    await expect(errorPage.errorTitle).toHaveText('WebGL Not Supported')
+        // Verify responsive styling
+        const boundingBox = await webGLErrorPage.getErrorContainerBoundingBox()
+        expect(boundingBox).toBeTruthy()
 
-    // Verify that helpful suggestions are shown
-    await expect(errorPage.suggestions).toHaveCount(4)
-
-    // Check specific suggestion text
-    await expect(errorPage.getSuggestionAt(0)).toContainText('modern browser')
-    await expect(errorPage.getSuggestionAt(1)).toContainText('hardware acceleration')
-    await expect(errorPage.getSuggestionAt(2)).toContainText('graphics drivers')
-    await expect(errorPage.getSuggestionAt(3)).toContainText('WebGL is blocked')
-
-    // Verify that the status overlay is NOT displayed
-    await expect(errorPage.statusOverlay).toBeHidden()
-
-    // Verify that the canvas still exists (even though WebGL failed)
-    await expect(errorPage.canvas).toBeVisible()
-
-    await context.close()
+        // On mobile, the error container should be 95% width
+        const viewportWidth = 375
+        const expectedMaxWidth = viewportWidth * 0.95
+        expect(boundingBox!.width).toBeLessThanOrEqual(expectedMaxWidth)
+      })
+    })
   })
 
-  test('renders 3D scene when WebGL is enabled', async ({ page }) => {
-    const approachPage = new ApproachVisualizerPage(page)
+  test('renders 3D scene when WebGL is enabled', async ({ approachPage, webGLErrorPage }) => {
     await approachPage.goto()
-    await page.waitForLoadState('domcontentloaded')
+    await approachPage.page.waitForLoadState('domcontentloaded')
 
     // Verify that the error message is NOT displayed
-    const errorPage = new WebGLErrorPage(page)
-    await expect(errorPage.errorContainer).toBeHidden()
+    await expect(webGLErrorPage.errorContainer).toBeHidden()
 
     // Verify that the status overlay IS displayed
     await expect(approachPage.statusOverlay.container).toBeVisible({ timeout: 10000 })
@@ -89,35 +66,5 @@ test.describe('WebGL Error Handling', () => {
 
     // Verify canvas is present
     await expect(approachPage.canvas).toBeVisible()
-  })
-
-  test('error message is responsive on mobile', async ({ browser }) => {
-    // Create a mobile viewport context with WebGL disabled
-    const context = await browser.newContext({
-      viewport: { width: 375, height: 667 },
-      ...(browser.browserType().name() === 'chromium' && {
-        args: ['--disable-webgl', '--disable-webgl2'],
-      }),
-    })
-
-    const page = await context.newPage()
-    await page.addInitScript(webGLDisableScript)
-
-    const errorPage = new WebGLErrorPage(page)
-    await errorPage.goto()
-
-    // Check that error message is displayed and responsive
-    await expect(errorPage.errorContainer).toBeVisible({ timeout: 10000 })
-
-    // Verify responsive styling
-    const boundingBox = await errorPage.getErrorContainerBoundingBox()
-    expect(boundingBox).toBeTruthy()
-
-    // On mobile, the error container should be 95% width
-    const viewportWidth = 375
-    const expectedMaxWidth = viewportWidth * 0.95
-    expect(boundingBox!.width).toBeLessThanOrEqual(expectedMaxWidth)
-
-    await context.close()
   })
 })

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -415,7 +415,9 @@ useTimeoutFn(() => {
       <div class="form-controls">
         <div class="form-field-group">
           <div class="form-field form-field-select">
-            <label for="approach-minimum">{{ t('controls.approachMinimum') }}</label>
+            <label for="approach-minimum" data-testid="approach-minimum-label">{{
+              t('controls.approachMinimum')
+            }}</label>
             <Select
               v-model="selectedMinimum"
               :options="approachMinimaOptions"
@@ -488,6 +490,7 @@ useTimeoutFn(() => {
           <Slider
             v-model="positionSlider"
             class="full-width-slider"
+            data-testid="position-slider"
             :min="0"
             :max="100"
             :step="0.1"
@@ -499,6 +502,7 @@ useTimeoutFn(() => {
             :key="`tick-${index}`"
             class="visibility-tick"
             :class="mark.class"
+            :data-testid="mark.class === 'breakout-tick' ? 'breakout-tick' : undefined"
             :style="{ left: `${mark.position}%` }"
             v-tooltip.top="mark.label"
           >

--- a/src/components/RunwayViewer.vue
+++ b/src/components/RunwayViewer.vue
@@ -93,11 +93,12 @@ watch(
     </div>
 
     <!-- Status Overlay -->
-    <div v-else class="status-overlay">
+    <div v-else class="status-overlay" data-testid="status-overlay">
       <div class="status-item">
-        <span class="status-label">{{ t('status.altitude') }}</span>
+        <span class="status-label" data-testid="altitude-label">{{ t('status.altitude') }}</span>
         <span
           class="status-value"
+          data-testid="altitude-value"
           :class="{
             'below-ceiling': animationStore.currentAltitude <= approachStore.effectiveCeiling,
           }"
@@ -105,10 +106,13 @@ watch(
         >
       </div>
       <div class="status-item">
-        <span class="status-label">{{ t('status.distance') }}</span>
-        <span class="status-value" :class="{ 'within-visibility': isWithinVisibility }">{{
-          formatNauticalMiles(animationStore.currentDistanceNm)
-        }}</span>
+        <span class="status-label" data-testid="distance-label">{{ t('status.distance') }}</span>
+        <span
+          class="status-value"
+          data-testid="distance-value"
+          :class="{ 'within-visibility': isWithinVisibility }"
+          >{{ formatNauticalMiles(animationStore.currentDistanceNm) }}</span
+        >
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary

Targeted fixes toward the Playwright UI/E2E test guidance. No production behavior changes — only added `data-testid` hooks and restructured test plumbing.

### Finding 1 — locator resilience
Component objects reached into CSS classes and positional `first()`/`last()` indexes that restyling would break.

- Added `data-testid` to the real Vue sources:
  - `RunwayViewer.vue`: `status-overlay`, `altitude-label`, `altitude-value`, `distance-label`, `distance-value`
  - `AppHeader.vue`: `position-slider` (on the PrimeVue `Slider`, which forwards it to the `.p-slider` root), `breakout-tick` (only on the cloud-breakout tick, not the other `v-for` ticks), and `approach-minimum-label`
- Switched `StatusOverlay`, `PositionSlider`, and `ApproachVisualizerPage` from `.status-label:has-text(...)` / `.status-value` first/last / `.p-slider` / `.breakout-tick` to `getByTestId`.

### Finding 2 — fixtures / layering
- `webgl-error.spec.ts` no longer constructs page objects with `new WebGLErrorPage(page)` / `new ApproachVisualizerPage(page)` or builds custom contexts inline. WebGL disabling is now a `webGLDisabled` option fixture (`test.use({ webGLDisabled: true })`) that injects the init script via the `page` fixture; the mobile case uses `test.use({ viewport })`. The spec consumes the existing `approachPage` / `webGLErrorPage` fixtures.
- `locale.spec.ts` no longer inlines a raw `label[for="approach-minimum"]` locator; the approach-minimum label is exposed as `approachPage.approachMinimumLabel` and asserted through the fixture.

No findings deferred.

## Verification

- `pnpm type-check` (vue-tsc): pass
- `pnpm lint` (eslint, stylelint, oxlint, knip): pass
- `pnpm test:unit` (vitest): 14/14 pass
- `npx playwright test --list`: all 33 specs compile
- Full `npx playwright test --project=chromium` against a production preview build: **11/11 pass**, confirming every new `data-testid` renders and is located, the PrimeVue slider forwards its test id, and the fixture-based WebGL disabling drives the error state.
- WebKit could not run locally (blank render) — the unmodified `main` baseline fails identically under WebKit in this environment, so it is a pre-existing local limitation, not a regression. CI (chromium/webkit per the workflow) will run the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)